### PR TITLE
Set up PlatformIO project for ESP32

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,0 +1,5 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,0 +1,10 @@
+#include <Arduino.h>
+
+void setup() {
+    Serial.begin(115200);
+}
+
+void loop() {
+    Serial.println("ESP32 läuft...");
+    delay(1000);
+}


### PR DESCRIPTION
## Problem

Für das Projekt musste eine Firmware-Entwicklungsumgebung für den ESP32 eingerichtet werden.

## Lösung

Ein PlatformIO-Projekt wurde im Ordner `firmware` erstellt.

Folgende Komponenten wurden eingerichtet:

- PlatformIO Projektstruktur
- ESP32 Dev Module Konfiguration
- Arduino Framework
- Serial Monitor Testprogramm

## Änderungen

- platformio.ini erstellt
- src/main.cpp mit einfachem Testprogramm hinzugefügt

## Test

Der Code wurde erfolgreich getestet.

Serial Monitor Ausgabe:

ESP32 läuft...

## Verknüpfung

Fixes #4