### PR TITLE
Add test button route for ESP32 webserver

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -44,14 +44,18 @@ void handleRoot() {
 <body>
     <h1>ESP32 Roboterarm</h1>
     <p>Webserver läuft erfolgreich.</p>
-    <button onclick="alert('Button 1 wurde geklickt')">Button 1</button>
-    <button onclick="alert('Button 2 wurde geklickt')">Button 2</button>
+    <button onclick="window.location.href='/test'">Test Button</button>
 </body>
 </html>
 )rawliteral";
 
     Serial.println("Browser Anfrage auf / empfangen");
     server.send(200, "text/html", html);
+}
+
+void handleTest() {
+    Serial.println("TEST BUTTON GEDRUECKT!");
+    server.send(200, "text/plain", "Test erfolgreich");
 }
 
 void handleNotFound() {
@@ -78,6 +82,7 @@ void setup() {
     Serial.println(WiFi.localIP());
 
     server.on("/", handleRoot);
+    server.on("/test", handleTest);
     server.onNotFound(handleNotFound);
     server.begin();
 


### PR DESCRIPTION
## Problem

Die HTML-Testseite zeigte bisher nur statische Buttons ohne echte Funktion.

## Lösung

Eine neue Route `/test` wurde hinzugefügt. Ein Button auf der HTML-Seite ruft diese Route auf und löst eine sichtbare Reaktion im ESP32-Webserver aus.

## Änderungen

- Route `/test` hinzugefügt
- Handler `handleTest()` ergänzt
- HTML-Button mit Route verknüpft
- Ausgabe im Serial Monitor ergänzt

## Test

Erfolgreich getestet:
- HTML-Seite im Browser geöffnet
- Test Button geklickt
- Route `/test` aufgerufen
- Reaktion im Serial Monitor sichtbar

Fixes #8