### PR TITLE
Veralteten web-Ordner entfernen und Projektdokumentation erweitern

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,136 @@
 # ESP32 Web Robot Arm
 
-A practice and portfolio project for controlling a **6-axis robotic arm via a web interface running on an ESP32**.
+Ein ESP32-basiertes Projekt zur Steuerung eines 6-Achs-Roboterarms ueber eine Weboberflaeche im Browser.
 
-The project demonstrates how embedded hardware can be controlled through a browser interface using a built-in microcontroller web server.
+Der ESP32 startet einen eigenen WLAN-Access-Point und stellt die Bedienoberflaeche direkt selbst bereit. Die Steuerung erfolgt ohne zusaetzlichen Server oder Cloud-Dienst ueber HTML, CSS, JavaScript und eine kleine REST-aehnliche API auf dem Geraet.
 
----
+## Funktionen
 
-# Goal
+- Steuerung von 6 Servos ueber eine Weboberflaeche
+- Bewegung pro Servo ueber Plus-/Minus-Tasten
+- Individuelle Geschwindigkeitssteuerung pro Servo
+- Anfahren einer Grundstellung
+- Speichern einzelner Positionen als Sequenz
+- Ueberschreiben, Abspielen und Loeschen von Sequenzen
+- Persistente Speicherung der Sequenz im Flash
+- Auslieferung der Webdateien ueber LittleFS
 
-The goal of this project is to build a **browser-based control system for a robotic arm with multiple servo motors**.
+## Projektaufbau
 
-The ESP32 acts as a **WiFi web server**, allowing the robotic arm to be controlled from any device with a browser.
+- `firmware/` Firmware-Projekt auf Basis von PlatformIO
+- `firmware/src/main.cpp` Hauptlogik fuer WLAN, Webserver, Servo-Steuerung und Sequenzverwaltung
+- `firmware/data/` Weboberflaeche (`index.html`, `style.css`, `script.js`) fuer LittleFS
+- `docs/` technische Dokumentation
+- `hardware/` Hardware-Notizen und Schaltungsinformationen
 
----
+## Verwendete Technologien
 
-# Project Structure
+- ESP32
+- Arduino Framework
+- PlatformIO
+- C++
+- HTML / CSS / JavaScript
+- LittleFS
+- `WebServer`, `Preferences`, `ESP32Servo`
 
-* `firmware/` ESP32 source code
-* `firmware/data/` HTML, CSS and JavaScript files served from LittleFS on the ESP32
-* `web/` browser prototypes and experiments
-* `docs/` technical documentation
-* `hardware/` wiring and hardware notes
-* `images/` screenshots and photos
+## Hardware
 
----
+Geplant bzw. verwendet:
 
+- ESP32 Dev Board
+- 6 Servomotoren
+- Externe 5V-Stromversorgung fuer die Servos
+- Roboterarm-Gestell, z. B. 3D-gedruckt
 
+Optional:
 
-# Technologies
+- PCA9685 fuer erweiterte Servo-Ansteuerung
 
-* ESP32
-* C++
-* Arduino Framework
-* HTML / CSS / JavaScript
-* LittleFS
-* REST-style API
+## Voraussetzungen
 
----
+Fuer Build und Upload wird benoetigt:
 
-# Firmware Upload
+- [PlatformIO](https://platformio.org/)
+- Ein per USB angeschlossener ESP32
+- Python bzw. PlatformIO-CLI in einer funktionierenden lokalen Umgebung
 
-The web interface is split into separate files in `firmware/data/` and is served from the ESP32 file system.
+## Konfiguration
 
-After flashing the firmware, upload the LittleFS data partition as well:
+Die wichtigsten Projektparameter stehen in `firmware/platformio.ini`.
+
+Standardmaessig startet der ESP32 mit:
+
+- WLAN-Name: `ESP32-Roboterarm`
+- Passwort: `robotarm123`
+
+Diese Werte koennen ueber `build_flags` angepasst werden.
+
+## Build
+
+```powershell
+cd firmware
+pio run
+```
+
+## Firmware und Webdateien auf den ESP32 laden
+
+Da die Weboberflaeche in `firmware/data/` liegt und ueber LittleFS ausgeliefert wird, muessen Firmware und Dateisystem getrennt uebertragen werden.
+
+### 1. Firmware flashen
 
 ```powershell
 cd firmware
 pio run -t upload
+```
+
+### 2. LittleFS-Dateien hochladen
+
+```powershell
+cd firmware
 pio run -t uploadfs
 ```
 
----
+Empfehlung: Nach Aenderungen an `index.html`, `style.css` oder `script.js` immer `uploadfs` ausfuehren.
 
-# Learning Goals
+## Nutzung
 
-This project is intended to practice:
+1. ESP32 per USB mit Strom versorgen oder normal starten.
+2. Mit einem Smartphone, Tablet oder Laptop in das WLAN `ESP32-Roboterarm` wechseln.
+3. Im Browser `http://192.168.4.1/` aufrufen.
+4. Servos manuell bewegen, Geschwindigkeiten anpassen und Sequenzen speichern oder abspielen.
 
-* Embedded systems programming
-* Hardware control using microcontrollers
-* Web servers on embedded devices
-* Modular software architecture
-* API-driven hardware control
+## Bedienkonzept
 
----
+- Plus-/Minus-Tasten bewegen den jeweiligen Servo schrittweise
+- Ein Slider pro Servo stellt die Bewegungsgeschwindigkeit ein
+- `Grundstellung` faehrt alle Servos in ihre Home-Position
+- `Position speichern` haengt die aktuelle Stellung an die Sequenz an
+- `Sequenz ueberschreiben` ersetzt die bestehende Sequenz durch die aktuelle Position
+- `Sequenz abspielen` faehrt alle gespeicherten Schritte nacheinander ab
+- `Sequenz loeschen` entfernt die gespeicherten Schritte
+- `STOP` beendet laufende Bewegungen bzw. Sequenzwiedergabe
 
-# Planned Hardware
+## Persistenz
 
-* ESP32 microcontroller
-* 6 servo motors
-* 3D printed robotic arm
-* external 5V power supply
+Gespeicherte Sequenzen werden ueber `Preferences` im Flash des ESP32 abgelegt und nach einem Neustart automatisch wieder geladen.
 
-Optional:
+## Bekannte Hinweise
 
-* PCA9685 servo controller
+- Die Servos sollten nicht direkt ueber den 5V-Pin eines USB-Anschlusses versorgt werden.
+- Fuer stabile Bewegungen ist eine separate Stromversorgung fuer die Servos empfehlenswert.
+- Nach Aenderungen an der Weboberflaeche reicht ein normales Firmware-Flashen nicht aus, solange `uploadfs` nicht ebenfalls ausgefuehrt wurde.
 
----
+## Entwicklungsziel
 
-# License
+Das Projekt dient als Lern- und Praxisprojekt fuer:
 
-MIT License
+- Embedded-Programmierung mit ESP32
+- Ansteuerung mehrerer Servos
+- Webserver auf Mikrocontrollern
+- Zustandsverwaltung und persistente Speicherung
+- Trennung von Firmware und Weboberflaeche
+
+## Lizenz
+
+Dieses Projekt steht unter der MIT-Lizenz. Details stehen in `LICENSE`.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Ein ESP32-basiertes Projekt zur Steuerung eines 6-Achs-Roboterarms ueber eine We
 
 Der ESP32 startet einen eigenen WLAN-Access-Point und stellt die Bedienoberflaeche direkt selbst bereit. Die Steuerung erfolgt ohne zusaetzlichen Server oder Cloud-Dienst ueber HTML, CSS, JavaScript und eine kleine REST-aehnliche API auf dem Geraet.
 
+## Navigation
+
+- [Dokumentationsuebersicht](docs/README.md)
+- [Architektur](docs/architecture.md)
+- [API-Dokumentation](docs/api.md)
+- [Hardware](docs/hardware.md)
+- [Deployment](docs/deployment.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Projektplan](docs/project-plan.md)
+
 ## Funktionen
 
 - Steuerung von 6 Servos ueber eine Weboberflaeche
@@ -129,6 +139,15 @@ Das Projekt dient als Lern- und Praxisprojekt fuer:
 - Webserver auf Mikrocontrollern
 - Zustandsverwaltung und persistente Speicherung
 - Trennung von Firmware und Weboberflaeche
+
+## Weiterfuehrende Dokumentation
+
+Fuer technische Details und Projektpflege:
+
+- [Dokumentationsuebersicht](docs/README.md)
+- [Architektur](docs/architecture.md)
+- [API-Dokumentation](docs/api.md)
+- [Projektplan](docs/project-plan.md)
 
 ## Lizenz
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,43 @@
+# Dokumentation
+
+Diese Uebersicht dient als Einstieg in die Projektdokumentation.
+
+## Navigation
+
+- [Architektur](architecture.md)
+- [API-Dokumentation](api.md)
+- [Hardware](hardware.md)
+- [Deployment](deployment.md)
+- [Troubleshooting](troubleshooting.md)
+- [Projektplan](project-plan.md)
+- [Haupt-README](../README.md)
+
+## Inhalte
+
+- `architecture.md`
+  Beschreibt den technischen Aufbau des Systems, die Hauptkomponenten und das Laufzeitverhalten.
+
+- `api.md`
+  Dokumentiert die HTTP-Endpunkte der Firmware inklusive Parametern, Antworten und typischem Verhalten.
+
+- `project-plan.md`
+  Enthaelt den aktuellen Projektstand, offene Themen und moegliche naechste Ausbaustufen.
+
+- `hardware.md`
+  Beschreibt die verwendete Hardware, Servo-Pins, Stromversorgung und Sicherheitsaspekte.
+
+- `deployment.md`
+  Dokumentiert Build, Flash-Workflow, LittleFS-Upload und Funktionstest nach dem Deployment.
+
+- `troubleshooting.md`
+  Sammelt typische Fehlerbilder und konkrete Schritte zur Fehlersuche.
+
+## Empfohlene Lesereihenfolge
+
+1. `architecture.md`
+2. `api.md`
+3. `project-plan.md`
+
+## Zweck des Ordners
+
+Der Ordner `docs/` soll die technische Projektdokumentation enthalten, waehrend die zentrale Projektuebersicht in der README im Repository-Root bleibt.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,244 @@
+# API-Dokumentation
+
+Zur Dokumentationsuebersicht: [docs/README.md](README.md)
+
+## Uebersicht
+
+Die Firmware stellt eine einfache HTTP-basierte API zur Steuerung des Roboterarms bereit. Alle Endpunkte werden direkt vom ESP32 bedient.
+
+Basisadresse im Standardfall:
+
+`http://192.168.4.1`
+
+Die Weboberflaeche selbst nutzt diese Endpunkte direkt ueber `fetch()`.
+
+## Statische Dateien
+
+### `GET /`
+
+Liefert die Weboberflaeche aus `index.html`.
+
+Antwort:
+
+- `200 OK` mit `text/html`
+- `404 Not Found`, wenn die Datei auf LittleFS fehlt
+
+### `GET /style.css`
+
+Liefert das Stylesheet der Weboberflaeche.
+
+### `GET /script.js`
+
+Liefert die Browserlogik der Weboberflaeche.
+
+## Servo-Bewegung
+
+### `GET /startMove?servo=<id>&dir=<direction>`
+
+Startet die manuelle Bewegung eines Servos.
+
+Parameter:
+
+- `servo`: Servo-ID von `0` bis `5`
+- `dir`: `-1` fuer negative Bewegung oder `1` fuer positive Bewegung
+
+Antworten:
+
+- `200 OK` mit `move start`
+- `400 Bad Request` bei fehlenden oder ungueltigen Parametern
+
+Beispiel:
+
+`/startMove?servo=2&dir=1`
+
+### `GET /stopMove?servo=<id>`
+
+Stoppt die manuelle Bewegung eines Servos.
+
+Parameter:
+
+- `servo`: Servo-ID von `0` bis `5`
+
+Antworten:
+
+- `200 OK` mit `move stop`
+- `400 Bad Request` bei ungueltiger Servo-ID
+
+Beispiel:
+
+`/stopMove?servo=2`
+
+## Geschwindigkeiten
+
+### `GET /setSpeed?servo=<id>&value=<speed>`
+
+Setzt die Bewegungsgeschwindigkeit eines Servos.
+
+Parameter:
+
+- `servo`: Servo-ID von `0` bis `5`
+- `value`: Geschwindigkeitswert von `1` bis `10`
+
+Antworten:
+
+- `200 OK` mit `speed updated`
+- `400 Bad Request` bei fehlenden oder ungueltigen Parametern
+
+Beispiel:
+
+`/setSpeed?servo=4&value=8`
+
+### `GET /speeds`
+
+Liefert die aktuellen Geschwindigkeitswerte aller Servos als JSON-Array.
+
+Antwortbeispiel:
+
+```json
+[5,5,5,5,5,5]
+```
+
+## Positionen
+
+### `GET /positions`
+
+Liefert die aktuellen Positionen aller sechs Servos als JSON-Array.
+
+Antwortbeispiel:
+
+```json
+[18,90,180,96,0,90]
+```
+
+## Grundfunktionen
+
+### `GET /home`
+
+Faehrt alle Servos in die definierte Grundstellung.
+
+Antworten:
+
+- `200 OK` mit `home`
+
+### `GET /stop`
+
+Stoppt die aktuelle Sequenzwiedergabe und beendet laufende Bewegungen.
+
+Antworten:
+
+- `200 OK` mit `stop`
+
+## Sequenzverwaltung
+
+### `GET /record`
+
+Speichert die aktuelle Servo-Position als neuen Sequenzschritt.
+
+Verhalten:
+
+- stoppt zunaechst eine laufende Sequenz
+- haengt die aktuelle Stellung an die gespeicherte Sequenz an
+- speichert die Sequenz anschliessend persistent im Flash
+
+Antworten:
+
+- `200 OK` mit `recorded`
+- `400 Bad Request` mit `sequence limit reached`
+- `500 Internal Server Error` mit `persist failed`
+
+### `GET /overwriteSequence`
+
+Loescht die bestehende Sequenz und ersetzt sie durch genau einen neuen Schritt mit der aktuellen Position.
+
+Antworten:
+
+- `200 OK` mit `overwritten`
+- `400 Bad Request` mit `sequence limit reached`
+- `500 Internal Server Error` mit `persist failed`
+
+### `GET /playSequence`
+
+Startet die Wiedergabe der gespeicherten Sequenz.
+
+Antworten:
+
+- `200 OK` mit `play sequence`
+- `400 Bad Request` mit `no recorded sequence`
+
+### `GET /clearSequence`
+
+Loescht die gespeicherte Sequenz und speichert den leeren Zustand persistent.
+
+Antworten:
+
+- `200 OK` mit `clear`
+- `500 Internal Server Error` mit `persist failed`
+
+## Sequenzstatus
+
+### `GET /sequenceStatus`
+
+Liefert einen kompakten Status der Sequenzwiedergabe.
+
+Antwortbeispiel:
+
+```json
+{
+  "count": 4,
+  "playing": true,
+  "currentStep": 1
+}
+```
+
+Bedeutung:
+
+- `count`: Anzahl gespeicherter Schritte
+- `playing`: gibt an, ob gerade abgespielt wird
+- `currentStep`: aktueller Schritt oder `-1`, wenn nichts aktiv ist
+
+### `GET /sequenceData`
+
+Liefert den kompletten Sequenzstatus inklusive aller gespeicherten Schritte.
+
+Antwortbeispiel:
+
+```json
+{
+  "count": 2,
+  "playing": false,
+  "currentStep": -1,
+  "steps": [
+    [18,90,180,96,0,90],
+    [30,80,150,96,10,100]
+  ]
+}
+```
+
+## Fehlerverhalten
+
+Typische Fehlerursachen:
+
+- fehlender Query-Parameter
+- ungueltige Servo-ID
+- ungueltiger Richtungswert
+- ungueltiger Geschwindigkeitswert
+- keine gespeicherte Sequenz vorhanden
+- Persistenzfehler beim Schreiben in den Flash
+
+Die API verwendet derzeit einfache Textantworten fuer Fehler und kein einheitliches JSON-Fehlerformat.
+
+## Hinweise fuer Weiterentwicklung
+
+Sinnvolle Erweiterungen der API:
+
+- `POST` statt `GET` fuer schreibende Operationen
+- einheitliche JSON-Fehlerobjekte
+- Endpunkt fuer Systemstatus
+- Endpunkt fuer WLAN- und Speicherinformationen
+- Import/Export kompletter Sequenzen
+
+Weiter zu:
+
+- [Architektur](architecture.md)
+- [Deployment](deployment.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,199 @@
+# Architektur
+
+Zur Dokumentationsuebersicht: [docs/README.md](README.md)
+
+## Ziel des Systems
+
+Das Projekt steuert einen 6-Achs-Roboterarm direkt ueber einen ESP32. Der Mikrocontroller uebernimmt gleichzeitig:
+
+- WLAN-Access-Point
+- HTTP-Webserver
+- Auslieferung der Weboberflaeche
+- Servo-Ansteuerung
+- Sequenzverwaltung
+- persistente Speicherung der Sequenz
+
+Die Architektur ist bewusst kompakt gehalten: Firmware, Webserver und UI liegen nah beieinander, damit das System ohne externe Infrastruktur betrieben werden kann.
+
+## Hauptkomponenten
+
+### ESP32-Firmware
+
+Die zentrale Logik liegt in `firmware/src/main.cpp`.
+
+Verantwortlichkeiten:
+
+- Initialisierung von LittleFS
+- Start des WLAN-Access-Points
+- Initialisierung der sechs Servos
+- Registrierung aller HTTP-Endpunkte
+- zyklische Servo-Bewegung im `loop()`
+- Verwaltung und Wiedergabe gespeicherter Sequenzen
+- Speicherung der Sequenz ueber `Preferences`
+
+### Weboberflaeche
+
+Die Weboberflaeche liegt in `firmware/data/` und wird ueber LittleFS ausgeliefert.
+
+Dateien:
+
+- `index.html` strukturiert die Bedienoberflaeche
+- `style.css` definiert Layout und Darstellung
+- `script.js` enthaelt die gesamte Browserlogik fuer Bedienung, Polling und API-Aufrufe
+
+### Persistenz
+
+Gespeicherte Sequenzen werden nicht im Dateisystem, sondern ueber `Preferences` im Flash des ESP32 abgelegt.
+
+Dabei werden gespeichert:
+
+- ein Header mit Magic-Value und Versionsnummer
+- die Anzahl der gespeicherten Schritte
+- die Servopositionen aller Schritte
+
+## Laufzeitverhalten
+
+### Startphase
+
+Beim Start passiert in dieser Reihenfolge:
+
+1. Serielle Schnittstelle wird initialisiert
+2. LittleFS wird gemountet
+3. der ESP32 startet den Access-Point
+4. alle Servos werden auf ihre Home-Position gesetzt
+5. eine zuvor gespeicherte Sequenz wird aus `Preferences` geladen
+6. der HTTP-Server und die statischen Dateien werden registriert
+
+### Regelbetrieb
+
+Im `loop()` laufen drei zentrale Aufgaben:
+
+1. `server.handleClient()` verarbeitet eingehende HTTP-Anfragen
+2. `updateServosSmoothly()` bewegt Servos schrittweise in Richtung Zielposition
+3. `updateSequence()` verwaltet die Wiedergabe gespeicherter Sequenzen
+
+## Bewegungsmodell
+
+Die Firmware unterscheidet zwischen:
+
+- aktueller Position `servoPositions`
+- Zielposition `servoTargets`
+- manueller Bewegungsrichtung `servoMoveDirection`
+- Geschwindigkeit `servoSpeeds`
+
+Manuelle Bewegung:
+
+- Beim Gedrueckthalten eines Buttons wird fuer einen Servo `-1` oder `1` als Richtung gesetzt.
+- Der Servo bewegt sich daraufhin schrittweise innerhalb seiner Min-/Max-Grenzen.
+- Beim Loslassen wird die Bewegung gestoppt und die aktuelle Position als Ziel uebernommen.
+
+Automatische Bewegung:
+
+- Bei Grundstellung oder Sequenzwiedergabe werden Zielpositionen gesetzt.
+- Die eigentliche Bewegung erfolgt weiterhin schrittweise im Hintergrund.
+
+## Geschwindigkeitsmodell
+
+Jeder Servo besitzt einen eigenen Geschwindigkeitswert von `1` bis `10`.
+
+- `1` bedeutet langsame Bewegung
+- `10` bedeutet schnelle Bewegung
+
+Intern wird der Wert auf ein Zeitintervall zwischen einzelnen Servo-Schritten abgebildet.
+
+## Sequenzmodell
+
+Eine Sequenz besteht aus mehreren Schritten. Jeder Schritt enthaelt genau sechs Zielwerte, einen pro Servo.
+
+Eigenschaften:
+
+- maximal `128` gespeicherte Schritte
+- zwischen zwei Schritten gibt es eine Haltezeit von `1000 ms`
+- die Sequenz wird nur abgespielt, wenn mindestens ein Schritt vorhanden ist
+
+Wichtige interne Funktionen:
+
+- `recordCurrentPosition()`
+- `applySequenceStep()`
+- `startRecordedSequenceInternal()`
+- `stopSequenceInternal()`
+- `updateSequence()`
+
+## Netzwerkmodell
+
+Der ESP32 arbeitet als eigener Access-Point.
+
+Standardwerte:
+
+- SSID: `ESP32-Roboterarm`
+- Passwort: `robotarm123`
+- Weboberflaeche: `http://192.168.4.1/`
+
+Die Werte koennen in `firmware/platformio.ini` ueber Build-Flags angepasst werden.
+
+## Speicher- und Dateimodell
+
+### LittleFS
+
+LittleFS wird fuer die statischen Webdateien verwendet:
+
+- `/index.html`
+- `/style.css`
+- `/script.js`
+
+Wichtig:
+
+- Nach Aenderungen an den Dateien in `firmware/data/` muss `pio run -t uploadfs` ausgefuehrt werden.
+
+### Preferences
+
+`Preferences` speichert die Sequenz dauerhaft unter dem Namespace `robotarm`.
+
+Verwendete Schluessel:
+
+- `seqHdr`
+- `seqData`
+
+## Servo-Konfiguration
+
+Der aktuelle Code definiert folgende Servo-Pins:
+
+- Servo 0: GPIO 13
+- Servo 1: GPIO 12
+- Servo 2: GPIO 14
+- Servo 3: GPIO 27
+- Servo 4: GPIO 26
+- Servo 5: GPIO 25
+
+Zusatzlich besitzt jeder Servo:
+
+- eine Minimalposition
+- eine Maximalposition
+- eine Home-Position
+
+Diese Werte sind fest in `main.cpp` hinterlegt und sollten bei Aenderungen an der Mechanik entsprechend angepasst werden.
+
+## Aktuelle Architekturgrenzen
+
+Die aktuelle Architektur ist fuer ein kleines Embedded-Projekt passend, hat aber bewusst einfache Grenzen:
+
+- Backend-Logik liegt noch komplett in einer Datei
+- keine Trennung in Module fuer Netzwerk, Servos und Persistenz
+- keine Authentifizierung fuer die Weboberflaeche
+- kein Konfigurationsmenue fuer Kalibrierung im Browser
+- kein formales Fehler- oder Ereignislogging ausser serieller Ausgabe
+
+## Sinnvolle naechste Ausbaustufen
+
+- Aufteilung von `main.cpp` in mehrere Module
+- zentrale Konfigurationsstruktur fuer Servo-Parameter
+- API-Dokumentation weiter ausbauen
+- zusaetzliche Diagnose-Endpunkte
+- Import/Export von Sequenzen
+- Bearbeiten einzelner Sequenzschritte in der Weboberflaeche
+
+Weiter zu:
+
+- [API-Dokumentation](api.md)
+- [Hardware](hardware.md)
+- [Projektplan](project-plan.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,120 @@
+# Deployment
+
+Zur Dokumentationsuebersicht: [docs/README.md](README.md)
+
+## Ziel
+
+Diese Datei beschreibt, wie die Firmware und die Weboberflaeche auf den ESP32 uebertragen werden.
+
+## Voraussetzungen
+
+- PlatformIO ist installiert
+- der ESP32 ist per USB verbunden
+- das Projekt wurde lokal geoeffnet oder geklont
+- die Verbindung zum richtigen COM-Port funktioniert
+
+## Wichtige Dateien
+
+- Firmware-Code: `firmware/src/main.cpp`
+- Weboberflaeche: `firmware/data/index.html`, `firmware/data/style.css`, `firmware/data/script.js`
+- Projektkonfiguration: `firmware/platformio.ini`
+
+## Build
+
+Vor einem Upload empfiehlt sich ein normaler Build:
+
+```powershell
+cd firmware
+pio run
+```
+
+## Firmware hochladen
+
+```powershell
+cd firmware
+pio run -t upload
+```
+
+Dieser Schritt uebertraegt den kompilierten Firmware-Code auf den ESP32.
+
+## LittleFS-Dateien hochladen
+
+```powershell
+cd firmware
+pio run -t uploadfs
+```
+
+Dieser Schritt erzeugt ein LittleFS-Image aus dem Ordner `firmware/data/` und schreibt es auf das Dateisystem des ESP32.
+
+## Wichtige Regel
+
+Bei Aenderungen an:
+
+- `index.html`
+- `style.css`
+- `script.js`
+
+reicht ein normaler Firmware-Upload nicht aus. In diesem Fall muss zusaetzlich `pio run -t uploadfs` ausgefuehrt werden.
+
+## Empfohlener Ablauf nach Codeaenderungen
+
+### Nur Firmware geaendert
+
+```powershell
+cd firmware
+pio run
+pio run -t upload
+```
+
+### Nur Weboberflaeche geaendert
+
+```powershell
+cd firmware
+pio run -t uploadfs
+```
+
+### Firmware und Weboberflaeche geaendert
+
+```powershell
+cd firmware
+pio run
+pio run -t upload
+pio run -t uploadfs
+```
+
+## Serielle Pruefung nach dem Upload
+
+Zum Beobachten des Startlogs:
+
+```powershell
+cd firmware
+pio device monitor --baud 115200
+```
+
+Typische serielle Meldungen:
+
+- erfolgreicher Start
+- LittleFS-Mount
+- Laden gespeicherter Sequenzen
+
+## Funktionstest nach dem Deployment
+
+1. Mit dem WLAN des ESP32 verbinden
+2. Browser auf `http://192.168.4.1/` oeffnen
+3. Servo-Bewegung testen
+4. Grundstellung testen
+5. Sequenz speichern und abspielen
+
+## Haeufige Fehlerquellen
+
+- falscher COM-Port
+- blockierter serieller Port
+- `uploadfs` nach Web-Aenderungen vergessen
+- ESP32 zwar gestartet, aber Endgeraet nicht mit dem Access-Point verbunden
+- LittleFS-Dateien fehlen oder sind veraltet
+
+Weiter zu:
+
+- [API-Dokumentation](api.md)
+- [Hardware](hardware.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -1,0 +1,84 @@
+# Hardware
+
+Zur Dokumentationsuebersicht: [docs/README.md](README.md)
+
+## Ziel
+
+Diese Datei beschreibt die aktuell verwendete bzw. vorgesehene Hardware fuer den ESP32-Web-Roboterarm.
+
+## Kernkomponenten
+
+- ESP32 Dev Board
+- 6 Servomotoren
+- externe 5V-Stromversorgung fuer die Servos
+- Roboterarm-Gestell
+- USB-Verbindung fuer Flash und serielle Diagnose
+
+## Servo-Anschluesse
+
+Der aktuelle Firmware-Stand verwendet folgende GPIO-Pins:
+
+- Servo 0: GPIO 13
+- Servo 1: GPIO 12
+- Servo 2: GPIO 14
+- Servo 3: GPIO 27
+- Servo 4: GPIO 26
+- Servo 5: GPIO 25
+
+Wichtig:
+
+- Die reale Verkabelung muss zu diesen Pins passen.
+- Wenn Servos auf andere Pins gelegt werden, muessen die Werte in `firmware/src/main.cpp` angepasst werden.
+
+## Logische Servo-Grenzen
+
+Die Firmware arbeitet aktuell mit festen Grenzwerten pro Servo:
+
+- Minimalposition
+- Maximalposition
+- Home-Position
+
+Diese Grenzen schuetzen die Mechanik vor ungueltigen oder unguenstigen Bewegungen. Sie sollten bei Aenderungen am Aufbau oder an der Mechanik neu geprueft werden.
+
+## Stromversorgung
+
+### ESP32
+
+Der ESP32 kann waehrend Entwicklung und Flashen ueber USB versorgt werden.
+
+### Servos
+
+Die Servos sollten ueber eine separate, ausreichend dimensionierte 5V-Stromversorgung betrieben werden.
+
+Empfehlung:
+
+- gemeinsame Masse zwischen ESP32 und externer Servo-Versorgung
+- Servo-Strom nicht direkt ueber den USB-Port oder den 5V-Pin des Boards ziehen, wenn mehrere Servos gleichzeitig arbeiten
+
+## Sicherheitshinweise
+
+- Mechanische Endanschlaege vor dem ersten Test pruefen
+- Servos zuerst mit vorsichtigen Grenzwerten betreiben
+- bei Blockieren oder starkem Zittern Spannungsversorgung und Grenzwerte pruefen
+- Arm bei ersten Tests nicht unbeaufsichtigt laufen lassen
+
+## Typische Risiken
+
+- Spannungseinbruch bei gleichzeitiger Servo-Bewegung
+- unruhige Bewegung durch zu schwache Stromversorgung
+- falsche Servo-Richtung oder unpassende Nullstellung
+- Kollisionen durch unguenstige Min-/Max-Werte
+
+## Empfohlene spaetere Ergaenzungen
+
+- Schaltplan oder Verdrahtungsbild
+- Foto des realen Aufbaus
+- genaue Angaben zu Servotypen
+- Angaben zu Stromaufnahme und Netzteil
+- Kalibrierhinweise pro Servo
+
+Weiter zu:
+
+- [Architektur](architecture.md)
+- [Deployment](deployment.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1,0 +1,89 @@
+# Projektplan
+
+Zur Dokumentationsuebersicht: [docs/README.md](README.md)
+
+## Projektziel
+
+Ziel des Projekts ist ein uebersichtlich aufgebauter, browserbasierter Roboterarm-Controller auf ESP32-Basis, der lokal im eigenen WLAN des Geraets betrieben werden kann.
+
+Der aktuelle Stand deckt bereits die Kernfunktionen fuer manuelle Steuerung, Geschwindigkeiten, Grundstellung, Sequenzen und persistente Speicherung ab.
+
+## Bereits umgesetzt
+
+- PlatformIO-Projekt fuer ESP32 eingerichtet
+- Webserver auf dem ESP32 umgesetzt
+- WLAN-Access-Point fuer den lokalen Zugriff eingerichtet
+- Steuerung von sechs Servos implementiert
+- Grundstellung fuer alle Servos umgesetzt
+- manuelle Bewegung ueber Weboberflaeche realisiert
+- individuelle Servo-Geschwindigkeiten umgesetzt
+- Sequenzen aufnehmen, loeschen, ueberschreiben und abspielen
+- persistente Speicherung von Sequenzen im Flash
+- Weboberflaeche aus `main.cpp` in separate Dateien ausgelagert
+- Auslieferung der Webdateien ueber LittleFS integriert
+- Legacy-Ordner `web/` entfernt
+- README und Projektdokumentation begonnen
+
+## Kurzfristige Ziele
+
+Diese Punkte sind als naechste praktische Verbesserungen sinnvoll:
+
+- Dokumentation in `docs/` weiter pflegen und aktuell halten
+- Hardware-Dokumentation im Ordner `hardware/` konkretisieren
+- Screenshots oder Demo-Bilder fuer README und Dokumentation ergaenzen
+- Fehler- und Randfaelle im Browser besser sichtbar machen
+- Bedienung auf Mobilgeraeten weiter testen
+
+## Mittelfristige Ziele
+
+- Quellcode in mehrere C++-Module aufteilen
+- Kalibrierung der Servo-Grenzen einfacher wartbar machen
+- API robuster und einheitlicher gestalten
+- einzelne Sequenzschritte im UI bearbeitbar machen
+- bessere Statusanzeigen fuer laufende Bewegungen und Speicherzustand
+- Export und Import von Sequenzen ermoeglichen
+
+## Langfristige Ziele
+
+- alternative Betriebsarten, z. B. Station-Mode statt nur Access-Point
+- Benutzer- oder Zugriffsschutz fuer Steuerfunktionen
+- Makros oder komplexere Bewegungsablaeufe
+- Telemetrie oder Diagnoseseite
+- Konfigurationsspeicherung fuer mehr als nur Sequenzen
+- moegliche Erweiterung um PCA9685 oder weitere Hardware
+
+## Offene technische Themen
+
+- bessere Trennung zwischen Bewegungslogik, Netzwerklogik und Persistenz
+- saubere Fehlerbehandlung und eventuell Logging-Konzept
+- Strategie fuer Tests, besonders fuer API- und Zustandslogik
+- Umgang mit Hardwaregrenzen und Kalibrierung bei veraenderter Mechanik
+
+## Vorschlag fuer Dokumentationsstruktur
+
+Die vorhandenen Dateien koennen so genutzt werden:
+
+- `architecture.md`: technischer Aufbau und Zusammenspiel der Komponenten
+- `api.md`: HTTP-Endpunkte, Parameter und Antworten
+- `project-plan.md`: Roadmap, naechste Schritte und offene Themen
+
+Sinnvolle spaetere Ergaenzungen:
+
+- `hardware.md` fuer Stromversorgung, Servo-Anschluesse und Sicherheitsaspekte
+- `deployment.md` fuer Flash- und Update-Prozess
+- `troubleshooting.md` fuer typische Fehlerbilder
+
+## Pflegehinweise
+
+Damit die Dokumentation nicht veraltet, sollte sie aktualisiert werden, wenn:
+
+- neue API-Endpunkte hinzukommen
+- sich Pins, Limits oder Home-Positionen aendern
+- die Weboberflaeche neue Kernfunktionen bekommt
+- sich der Flash- oder Upload-Prozess aendert
+
+Weiter zu:
+
+- [Architektur](architecture.md)
+- [API-Dokumentation](api.md)
+- [Deployment](deployment.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,141 @@
+# Troubleshooting
+
+Zur Dokumentationsuebersicht: [docs/README.md](README.md)
+
+## ESP32 startet, aber die Webseite ist nicht erreichbar
+
+Pruefen:
+
+- ist das Geraet mit dem WLAN `ESP32-Roboterarm` verbunden
+- wurde `http://192.168.4.1/` aufgerufen
+- startet der ESP32 als Access-Point
+- wurde LittleFS erfolgreich hochgeladen
+
+Moegliche Ursache:
+
+- das Testgeraet ist noch im Heimnetz statt im ESP32-WLAN
+
+## Webseite laedt, aber Aenderungen an HTML, CSS oder JS sind nicht sichtbar
+
+Moegliche Ursache:
+
+- die Dateien in `firmware/data/` wurden geaendert, aber `pio run -t uploadfs` wurde nicht ausgefuehrt
+
+Loesung:
+
+```powershell
+cd firmware
+pio run -t uploadfs
+```
+
+## Firmware laesst sich nicht hochladen
+
+Pruefen:
+
+- ist der ESP32 per USB verbunden
+- ist der richtige COM-Port verfuegbar
+- blockiert ein serieller Monitor den Port
+
+Typisches Problem:
+
+- `COMx` ist bereits in Benutzung
+
+Loesung:
+
+- seriellen Monitor schliessen
+- blockierende Prozesse beenden
+- Upload erneut starten
+
+## LittleFS-Upload funktioniert nicht
+
+Pruefen:
+
+- ist in `platformio.ini` `board_build.filesystem = littlefs` gesetzt
+- liegen die Webdateien im Ordner `firmware/data/`
+- wird wirklich `uploadfs` und nicht nur `upload` ausgefuehrt
+
+## ESP32 bootet, aber im Browser fehlt die Oberflaeche
+
+Moegliche Ursachen:
+
+- `/index.html` fehlt im LittleFS
+- das Dateisystem wurde nicht hochgeladen
+- LittleFS konnte nicht gemountet werden
+
+Pruefung:
+
+- seriellen Monitor starten
+- auf Meldungen wie `LittleFS Mount Failed` achten
+
+## Gespeicherte Sequenz ist nach Neustart weg
+
+Pruefen:
+
+- wurde die Position wirklich ueber die Weboberflaeche gespeichert
+- treten serielle Fehlermeldungen zur Persistenz auf
+- wurde die Sequenz eventuell geloescht oder ueberschrieben
+
+Hinweis:
+
+- die Sequenz wird ueber `Preferences` gespeichert, nicht ueber LittleFS
+
+## Servos bewegen sich nicht oder falsch
+
+Pruefen:
+
+- stimmen die GPIO-Pins mit der realen Verdrahtung ueberein
+- ist eine externe Stromversorgung vorhanden
+- sind Min-, Max- und Home-Werte passend fuer die Mechanik
+- ist die gemeinsame Masse zwischen ESP32 und Servo-Versorgung verbunden
+
+## Servos zittern oder der ESP32 startet neu
+
+Wahrscheinliche Ursache:
+
+- instabile oder zu schwache Stromversorgung
+
+Loesung:
+
+- separate 5V-Stromversorgung fuer die Servos verwenden
+- Masseverbindung zwischen Netzteil und ESP32 sicherstellen
+- Lastspitzen durch gleichzeitige Bewegungen beachten
+
+## API-Endpunkt liefert Fehler 400
+
+Moegliche Ursache:
+
+- fehlender oder ungueltiger Query-Parameter
+
+Beispiele:
+
+- falsche Servo-ID
+- ungueltiger Richtungswert
+- Geschwindigkeitswert ausserhalb des erlaubten Bereichs
+
+## API-Endpunkt liefert Fehler 500
+
+Moegliche Ursache:
+
+- Problem beim persistenten Speichern der Sequenz
+
+Empfohlene Pruefung:
+
+- seriellen Log beobachten
+- Speichervorgang erneut testen
+- Initialisierung und Flash-Zustand pruefen
+
+## Wenn gar nichts mehr weiterhilft
+
+Sinnvolle Reihenfolge:
+
+1. seriellen Monitor oeffnen
+2. Firmware neu flashen
+3. LittleFS neu hochladen
+4. ESP32 neu starten
+5. WLAN-Verbindung und Browser erneut pruefen
+
+Weiter zu:
+
+- [Deployment](deployment.md)
+- [Hardware](hardware.md)
+- [API-Dokumentation](api.md)


### PR DESCRIPTION
## Zusammenfassung
- den veralteten Ordner `web/` entfernt
- alte Prototyp-Dateien `web/index.html`, `web/style.css` und `web/app.js` geloescht
- README grundlegend ueberarbeitet und an den aktuellen Projektstand angepasst
- strukturierte Projektdokumentation im Ordner `docs/` aufgebaut
- Navigation zwischen README und den Dokumentationsseiten ergaenzt

## Neue Dokumentation
- `docs/architecture.md`
- `docs/api.md`
- `docs/project-plan.md`
- `docs/hardware.md`
- `docs/deployment.md`
- `docs/troubleshooting.md`
- `docs/README.md`

## Hintergrund
Mit Issue #40 wurde die produktive Weboberflaeche nach `firmware/data/` verschoben. Der alte Ordner `web/` wird nicht mehr verwendet und konnte deshalb entfernt werden. Im gleichen Zuge wurde die Projekt- und Technikdokumentation sauber aufgebaut.

## Verifikation
- Branch lokal erstellt und nach GitHub gepusht
- README und `docs/` auf den aktuellen Firmware-, LittleFS- und Upload-Workflow abgestimmt
- Dokumentationsnavigation zwischen den Dateien ergaenzt

Closes #40
